### PR TITLE
Fix: Resolve import error for get_embedding_provider

### DIFF
--- a/src/perquire/__init__.py
+++ b/src/perquire/__init__.py
@@ -11,10 +11,8 @@ __author__ = "Franklin Baldo"
 __email__ = "franklinbaldo@gmail.com"
 
 # Lightweight core - only expose provider factory functions
-from .providers import get_embedding_provider, get_llm_provider, list_available_providers
+from .providers import list_available_providers
 
 __all__ = [
-    "get_embedding_provider",
-    "get_llm_provider", 
     "list_available_providers",
 ]


### PR DESCRIPTION
Removes missing `get_embedding_provider` and `get_llm_provider` from imports and __all__ in `src/perquire/__init__.py` as these functions are not defined in `src/perquire/providers/__init__.py`.

This change allows the E2E tests to proceed past the initial import failures.