### PR TITLE
Implement Akinator module stubs

### DIFF
--- a/src/perquire/__init__.py
+++ b/src/perquire/__init__.py
@@ -12,7 +12,19 @@ __email__ = "franklinbaldo@gmail.com"
 
 # Lightweight core - only expose provider factory functions
 from .providers import list_available_providers
+from .akinator import (
+    WikipediaDatasetBuilder,
+    BatchEmbeddingGenerator,
+    MassiveQuestionGenerator,
+    OptimizedBootstrapInvestigator,
+    DimensionalAnalyzer,
+)
 
 __all__ = [
     "list_available_providers",
+    "WikipediaDatasetBuilder",
+    "BatchEmbeddingGenerator",
+    "MassiveQuestionGenerator",
+    "OptimizedBootstrapInvestigator",
+    "DimensionalAnalyzer",
 ]

--- a/src/perquire/akinator/__init__.py
+++ b/src/perquire/akinator/__init__.py
@@ -1,0 +1,13 @@
+"""Akinator-style investigation utilities."""
+
+from .knowledge_base import WikipediaDatasetBuilder, BatchEmbeddingGenerator
+from .question_bank import MassiveQuestionGenerator
+from .investigation import OptimizedBootstrapInvestigator, DimensionalAnalyzer
+
+__all__ = [
+    "WikipediaDatasetBuilder",
+    "BatchEmbeddingGenerator",
+    "MassiveQuestionGenerator",
+    "OptimizedBootstrapInvestigator",
+    "DimensionalAnalyzer",
+]

--- a/src/perquire/akinator/investigation.py
+++ b/src/perquire/akinator/investigation.py
@@ -1,0 +1,41 @@
+"""Akinator-style investigation engine components."""
+
+from __future__ import annotations
+
+from typing import List
+import numpy as np
+
+
+class OptimizedBootstrapInvestigator:
+    """Fast bootstrap using vectorized similarity."""
+
+    def __init__(self, knowledge_embeddings: np.ndarray):
+        self.knowledge_embeddings = knowledge_embeddings
+
+    def fast_bootstrap(self, target_embedding: np.ndarray, top_k: int = 10) -> List[int]:
+        sims = self._cosine_sim(target_embedding, self.knowledge_embeddings)
+        top_indices = np.argsort(-sims)[:top_k]
+        return top_indices.tolist()
+
+    @staticmethod
+    def _cosine_sim(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+        a_norm = a / (np.linalg.norm(a) + 1e-8)
+        b_norm = b / (np.linalg.norm(b, axis=1, keepdims=True) + 1e-8)
+        return np.dot(b_norm, a_norm)
+
+
+class DimensionalAnalyzer:
+    """Evaluate questions across semantic dimensions."""
+
+    def __init__(self, question_embeddings: np.ndarray):
+        self.question_embeddings = question_embeddings
+
+    def evaluate_all_dimensions(self, target_embedding: np.ndarray) -> np.ndarray:
+        sims = self._cosine_sim(target_embedding, self.question_embeddings)
+        return sims
+
+    @staticmethod
+    def _cosine_sim(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+        a_norm = a / (np.linalg.norm(a) + 1e-8)
+        b_norm = b / (np.linalg.norm(b, axis=1, keepdims=True) + 1e-8)
+        return np.dot(b_norm, a_norm)

--- a/src/perquire/akinator/knowledge_base.py
+++ b/src/perquire/akinator/knowledge_base.py
@@ -1,0 +1,57 @@
+"""Utilities for building a simple Wikipedia knowledge base."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+import json
+import numpy as np
+
+
+@dataclass
+class WikipediaConcept:
+    """Representation of a Wikipedia concept."""
+
+    title: str
+    category: str
+    url: str
+    embedding: List[float] | None = None
+
+
+class WikipediaDatasetBuilder:
+    """Create a small concept dataset for experimentation.
+
+    This is a very minimal placeholder implementation. A real implementation
+    would fetch data from Wikipedia APIs and curate a balanced concept list.
+    """
+
+    def build_dataset(self) -> List[WikipediaConcept]:
+        concepts = [
+            WikipediaConcept(
+                title="Coffee shop",
+                category="places",
+                url="https://en.wikipedia.org/wiki/Coffee_shop",
+            ),
+            WikipediaConcept(
+                title="Chair",
+                category="physical_objects",
+                url="https://en.wikipedia.org/wiki/Chair",
+            ),
+        ]
+        return concepts
+
+    def save_dataset(self, concepts: List[WikipediaConcept], path: str) -> None:
+        data = [concept.__dict__ for concept in concepts]
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2)
+
+
+class BatchEmbeddingGenerator:
+    """Generate simple random embeddings for a list of concepts."""
+
+    def __init__(self, dimensions: int = 8):
+        self.dimensions = dimensions
+
+    def generate(self, concepts: List[WikipediaConcept]) -> None:
+        for concept in concepts:
+            concept.embedding = np.random.rand(self.dimensions).astype(float).tolist()

--- a/src/perquire/akinator/question_bank.py
+++ b/src/perquire/akinator/question_bank.py
@@ -1,0 +1,48 @@
+"""Massive question generation utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Dict
+import json
+
+
+@dataclass
+class DimensionalQuestion:
+    """Question representing one pole of a semantic dimension."""
+
+    text: str
+    dimension: str
+    pole: str
+    category: str
+
+
+class MassiveQuestionGenerator:
+    """Generate a simple question bank.
+
+    This placeholder uses predefined examples instead of an LLM. In a full
+    implementation, questions would be generated with a language model and
+    embedded for similarity calculations.
+    """
+
+    def generate_question_bank(self) -> List[DimensionalQuestion]:
+        questions = [
+            DimensionalQuestion(
+                text="This represents something abstract",
+                dimension="abstraction_level",
+                pole="positive",
+                category="ontological",
+            ),
+            DimensionalQuestion(
+                text="This represents something concrete",
+                dimension="abstraction_level",
+                pole="negative",
+                category="ontological",
+            ),
+        ]
+        return questions
+
+    def save_question_bank(self, questions: List[DimensionalQuestion], path: str) -> None:
+        data = [q.__dict__ for q in questions]
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2)

--- a/src/perquire/embeddings/__init__.py
+++ b/src/perquire/embeddings/__init__.py
@@ -5,6 +5,7 @@ This module automatically registers available embedding providers with the centr
 """
 
 from .base import BaseEmbeddingProvider, EmbeddingResult, embedding_registry, EmbeddingError
+from ..exceptions import ConfigurationError
 from .gemini_embeddings import GeminiEmbeddingProvider
 from .openai_embeddings import OpenAIEmbeddingProvider # Added new provider
 from .utils import cosine_similarity, normalize_embedding
@@ -22,15 +23,15 @@ try:
         OpenAIEmbeddingProvider(config=DEFAULT_EMBEDDING_PROVIDER_CONFIGS["openai"]),
         set_as_default=True # Example: Set OpenAI as default
     )
-except EmbeddingError as e:
-    print(f"Note: OpenAI Embedding provider not fully configured: {e}") # Or use logger
+except (EmbeddingError, ConfigurationError) as e:
+    print(f"Note: OpenAI Embedding provider not fully configured: {e}")
 
 try:
     embedding_registry.register_provider(
         "gemini",
         GeminiEmbeddingProvider(config=DEFAULT_EMBEDDING_PROVIDER_CONFIGS["gemini"])
     )
-except EmbeddingError as e:
+except (EmbeddingError, ConfigurationError) as e:
     print(f"Note: Gemini Embedding provider not fully configured: {e}")
 
 

--- a/src/perquire/llm/__init__.py
+++ b/src/perquire/llm/__init__.py
@@ -5,6 +5,7 @@ This module automatically registers available LLM providers with the central reg
 """
 
 from .base import BaseLLMProvider, provider_registry, LLMProviderError
+from ..exceptions import ConfigurationError
 from .gemini_provider import GeminiProvider
 from .openai_provider import OpenAIProvider
 from .anthropic_provider import AnthropicProvider
@@ -28,15 +29,15 @@ try:
         OpenAIProvider(config=DEFAULT_PROVIDER_CONFIGS["openai"]),
         set_as_default=True # Example: set OpenAI as default if available
     )
-except LLMProviderError as e:
-    print(f"Note: OpenAI LLM provider not fully configured: {e}") # Or use logger
+except (LLMProviderError, ConfigurationError) as e:
+    print(f"Note: OpenAI LLM provider not fully configured: {e}")
 
 try:
     provider_registry.register_provider(
         "gemini",
         GeminiProvider(config=DEFAULT_PROVIDER_CONFIGS["gemini"])
     )
-except LLMProviderError as e:
+except (LLMProviderError, ConfigurationError) as e:
     print(f"Note: Gemini LLM provider not fully configured: {e}")
 
 try:
@@ -44,7 +45,7 @@ try:
         "anthropic",
         AnthropicProvider(config=DEFAULT_PROVIDER_CONFIGS["anthropic"])
     )
-except LLMProviderError as e:
+except (LLMProviderError, ConfigurationError) as e:
     print(f"Note: Anthropic LLM provider not fully configured: {e}")
 
 try:
@@ -52,7 +53,7 @@ try:
         "ollama",
         OllamaProvider(config=DEFAULT_PROVIDER_CONFIGS["ollama"])
     )
-except LLMProviderError as e:
+except (LLMProviderError, ConfigurationError) as e:
     print(f"Note: Ollama LLM provider not fully configured: {e}")
 
 

--- a/tests/akinator/test_akinator.py
+++ b/tests/akinator/test_akinator.py
@@ -1,0 +1,44 @@
+import numpy as np
+from perquire.akinator import (
+    WikipediaDatasetBuilder,
+    BatchEmbeddingGenerator,
+    MassiveQuestionGenerator,
+    OptimizedBootstrapInvestigator,
+    DimensionalAnalyzer,
+)
+
+
+def test_dataset_builder_creates_concepts():
+    builder = WikipediaDatasetBuilder()
+    concepts = builder.build_dataset()
+    assert len(concepts) >= 2
+    assert concepts[0].title
+
+
+def test_embedding_generator_adds_embeddings():
+    builder = WikipediaDatasetBuilder()
+    concepts = builder.build_dataset()
+    generator = BatchEmbeddingGenerator(dimensions=4)
+    generator.generate(concepts)
+    assert all(c.embedding is not None for c in concepts)
+    assert len(concepts[0].embedding) == 4
+
+
+def test_question_generator_produces_questions():
+    qgen = MassiveQuestionGenerator()
+    questions = qgen.generate_question_bank()
+    assert len(questions) >= 2
+    assert questions[0].text
+
+
+def test_bootstrap_and_dimensional_analysis():
+    rng = np.random.default_rng(0)
+    knowledge = rng.random((5, 4))
+    target = rng.random(4)
+    boot = OptimizedBootstrapInvestigator(knowledge)
+    top = boot.fast_bootstrap(target, top_k=3)
+    assert len(top) == 3
+    analyzer = DimensionalAnalyzer(knowledge)
+    sims = analyzer.evaluate_all_dimensions(target)
+    assert sims.shape[0] == 5
+

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -185,4 +185,3 @@ def test_cli_batch_command(runner, mock_investigator_instance, tmp_path):
     assert "dummy_emb_0.npy" in result.output # File names in summary
     assert "dummy_emb_1.npy" in result.output
     assert "dummy_emb_2.npy" in result.output
-```


### PR DESCRIPTION
## Summary
- add skeleton Akinator modules for knowledge base, question generation and investigation
- expose Akinator utilities from package root
- relax provider registration error handling
- fix stray code block in CLI tests
- add unit tests for new Akinator classes

## Testing
- `pytest tests/akinator/test_akinator.py -q`
- `pytest -q` *(fails: test suite requires unavailable provider configuration and async plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68649d2892348325a872b24292903a84