### PR TITLE
Fix DuckDB provider and result classes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ license = {text = "MIT"}
 dependencies = [
     "anthropic>=0.56.0",
     "click>=8.2.1",
-    "duckdb>=1.3.1",
+    "duckdb>=1.3.0",
+    "duckdb-extension-vss>=1.3.0",
     "google-generativeai>=0.8.5",
     "llama-index-core>=0.12.45",
     "llama-index-embeddings-gemini>=0.3.2",

--- a/tests/core/test_investigator.py
+++ b/tests/core/test_investigator.py
@@ -305,4 +305,3 @@ def test_get_model_config_includes_interrogator_strategy(mock_llm_provider, mock
     )
     config_default = investigator_default._get_model_config()
     assert config_default["interrogator_strategy"]["name"] == "DefaultInterrogatorStrategy"
-```

--- a/tests/database/test_duckdb_provider.py
+++ b/tests/database/test_duckdb_provider.py
@@ -322,4 +322,3 @@ def test_hash_consistency(in_memory_provider):
 # TODO: Add tests for error handling, e.g., DB connection errors (might require more mocking).
 # TODO: Test date/time storage and retrieval precision more rigorously.
 # TODO: Test handling of very large embeddings or large numbers of cache entries.
-```


### PR DESCRIPTION
## Summary
- add compatibility QuestionAnswer dataclass
- store iteration in metadata when adding questions
- handle string or datetime fields when loading InvestigationResult
- make DuckDBProvider resilient without VSS extension
- clean up stray markdown from tests
- include packaged VSS extension via dependency and load from local path

## Testing
- `pytest tests/database/test_duckdb_provider.py::TestDuckDBInvestigationStorage::test_save_and_load_investigation -q`
- `pytest -q` *(fails: 22 failed, 35 passed, 9 errors)*

------
https://chatgpt.com/codex/tasks/task_e_686de12cf0dc832598007ffddd741789